### PR TITLE
Public info requests for Old Baldy Mountain

### DIFF
--- a/info-requests.md
+++ b/info-requests.md
@@ -22,38 +22,272 @@ These requests are not documented, as unconfirmed or otherwise, within Black Hil
 
 - *Wrestling with a Grizzly Bear*, V8
 
-  From Dan Dewell's 8a logbook. Entry was added 5 June 2005 in an unknown sector of Iron Mountain with the description "crimpy 5\*boulder." It was rated 5/5 stars, implying it is quite a good problem. There were no other problems ticked around the same time. The word *Grizzly* in the name implies it may be in the *Grizzly Boulders* (northeastern *Land of the Way-Too-Highs*) or along *Grizzly Bear Creek*.
+  From Dan Dewell's 8a logbook. Entry was added 5 June 2005 in an unknown
+  sector of Iron Mountain with the description "crimpy 5\*boulder." It was
+  rated 5/5 stars, implying it is quite a good problem. There were no other
+  problems ticked around the same time. The word *Grizzly* in the name implies
+  it may be in the *Grizzly Boulders* (northeastern *Land of the
+  Way-Too-Highs*) or along *Grizzly Bear Creek*.
 
   [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BWrestling%20with%20a%20Grizzly%20Bear%5D)
 
 - *Illuminati*, V4
 
-  From Kai Segrund's 8a logbook. Entry was added 19 June 2009 in an uknown sector of the Black Hills with no description. This entry is accompanied by two "N.N." ticks of grades V2 and V3, added on the same day. I assume this problem exists on Iron Mountain Road since Gary Carnes added entries to his logbook the next day and the two are known acquaintances. Gary's entries from that day include the schist traverse and the *Light Bulb Moment* drop-off at *Rubik's Ridge*, and *Looks Like a Va-Jay-Jay* (*As the Skin Thins*) at *Turtle Dome*. This problem is likely an alias to a problem already in a Black Hills Bouldering publication.
+  From Kai Segrud's 8a logbook. Entry was added 19 June 2009 in an uknown
+  sector of the Black Hills with no description. This entry is accompanied by
+  two "N.N." ticks of grades V2 and V3, added on the same day. I assume this
+  problem exists on Iron Mountain Road since Gary Carnes added entries to his
+  logbook the next day and the two are known acquaintances. Gary's entries from
+  that day include the schist traverse and the *Light Bulb Moment* drop-off at
+  *Rubik's Ridge*, and *Looks Like a Va-Jay-Jay* (*As the Skin Thins*) at
+  *Turtle Dome*. This problem is likely an alias to a problem already in a
+  Black Hills Bouldering publication.
 
   [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BIlluminati%5D)
 
 ## Old Baldy Mountain
 
-- *Give It the Finger*, V7
+- *MC Ollie*, V4, Greg Parker
 
-  From Chipper Phillips and Justin Jaeger's 8a scorecards. Chipper Phillips' entry was made 30 May 2004 in an unknown sector of Old Baldy with a description "sit&go&stickitin." He gave it 3/5 stars and marked it as an FA. This entry is accompanied by an entry for *Stranglehold*. Justin Jaeger's entry was made 30 May 2004 in an unknown sector of the Black Hills with the description "burly crimp sds." He gate it 1/5 stars. It is accompanied by mulitple entries in *Irie Heights* such as *The Healing*, *The Offering*, and *Tastes Like Burning* as well as a *Sport Action Arete* eliminate. This all leads me to believe that *Give It the Finger* is a below average quality problem. It is most likely located somewhere in *Irie Heights*, but has the potential to be anywhere at Baldy, including along *Camp Judson Road*. The name and descriptions imply that it is a crimpy sit start, likely with a stab at some hold somehwere in the problem.
+  Likely between or around problems such as *Fisticuffs*/*Broken Hearts* and
+  *Hidden Adjenda*. Upon further discussion it seems *MC Ollie* was most likely
+  on *Schistty Ridge* in some manner. The ordering of the problems imply it's
+  left of *Broken Hearts*, though that isn't confirmed. Has been described as
+  possibly a "non-descript squattie."
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BMC%20Ollie%5D)
+
+  There are also a few more undefined problems a V1 and two V2s, all FA'd by Greg Parker as sit starts. These are likely to the right of *Fisticuffs*, near *Brilliant*, or somewhere close by.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BRandoms%20around%20Fisticuffs%20or%20Brillaint%5D)
+
+- Random/unnamed "backside"/*Irie Heights* problems
+
+  - *V0+ Travis Rypkema*
+
+    Likely near the subsequent problem.
+
+  - *One Move Dyno*, V1, Travis Rypkema
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BRandom%20backside%20problems%20by%20Travis%5D)
+
+  - Traverse into Dyno, V3, Greg Parker
+
+    Likely a traverse into the sesequent problem.
+
+  - Travis Dyno, V2
+
+    Travis Rypkema FA, or just a typo?
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BRandom%20backside%20dyno%20with%20traverse%5D)
+
+- Brain Fart, V6, Greg Parker
+
+  A problem described as "little 5' boulder that is really hard." Possibly near
+  the previous two problem sets.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BBrain%20Fart%5D)
+
+- Stolen Thunder, V4, Greg Parker
+
+  Sit start. Likely around the likes of *Isosceles Look-a-like*, *Grips*,
+  *Pulling Back a Stump*, etc.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BStolen%20Thunder%5D)
+
+- Pulling Back a Stump, V5, Greg Parker
+
+  Likely near the aforementioned and subsequently mentioned problems.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BPulling%20Back%20a%20Stump%5D)
+
+- Low-end, but kind of named, Travis problems
+
+  - Grips, V1, Travis Rypkema
+
+    Sit start
+
+  - Scary, V1, Travis Rypkema
+
+  - Pansy, V1, Travis Rypkema
+
+  - V0-, Travis Rypkema
+
+  - V0, Travis Rypkema
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BMore%20random%20backside%20problems%20by%20Travis%5D)
+
+- *Marcel's Block*
+
+  This is a large block developed by Marcel Mondova and Chipper Phillips. It is
+  located southeastwardly adjacent to *Stranglehold*. It is estimated 11-13
+  problems exist in the low-moderate grade range. The block is known, the
+  problems are not.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BMarcel%27s%20Block%5D)
+
+- *Ego Stroke Arete*, V8, Chuck Fryberger
+
+  From Chuck Fryberger's 8a scorecard. Entry was added 4 July 2003, in an
+  unknown sector of Black Hills with the description "FA verm beta." Given 1/5
+  stars. This entry is accompanied by an entry for *Goat Problem*, see below.
+  The following day, Chuck ticked *Making Puppies*, *Kiss the Groove*, and
+  *Dagron's Arete*. This leads me to believe these problems may be located
+  around Baldy or maybe in Wayward Valley. These were likely done during the
+  filming of *Friction Addiction*.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BEgo%20Stroke%20Arete%5D)
+
+- *Goat Problem*, V9, Chuck Fryberger
+
+  From Chuck Fryberger's 8a scorecard. Entry was added 4 July 2003, in an
+  unknown sector of Black Hills with the description "FA orange jump start"
+  Given 3/5 stars. This entry is accompanied by an entry for *Goat Problem*,
+  see above for more related commentary.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BGoat%20Problem%5D)
+
+- *Eggspression*, V4
+
+  From Dan Dewell's 8a scorecard. Entry was added 20 November 2003 in an
+  unknown sector at Baldy with the description "not great". The only stretch of
+  a lead I have on this problem is problems on *Eggstraordinary* are also
+  egg-themed..
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BEggspression%5D)
+
+- *Teen Girl Club*, V4
+
+  From Dan Dewell's 8a scorecard. Entry was added 23 December 2003 in and
+  unknown sector of Old Baldy with the description "short roof." It was
+  accompanied by a tick of *Right Handed Isosceles* the same day. I was told by
+  a third party it was near the *Almost There Boulders*, but I'm not too
+  convinced of that at the moment.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BTeen%20Girl%20Club%5D)
+
+- Mysterious Caddyshack Boulder Fryberger V8s
+
+  It has been reported to that Dan Dewell witnessed ascents of two V8-ish
+  problems on the tall, steep face of the Caddyshack Boulder by Chuck
+  Fryberger. I have assumed one of these V8 was a stand start left of
+  *Looming*. That problem is still unconfirmed. The second V8 on the otherhand
+  is a total mystery to me.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BCaddyshack-Fryberger%5D)
+
+- *Give It the Finger*, V7, Chipper Phillips
+
+  From Chipper Phillips and Justin Jaeger's 8a scorecards. Chipper Phillips'
+  entry was made 30 May 2004 in an unknown sector of Old Baldy with a
+  description "sit&go&stickitin." He gave it 3/5 stars and marked it as an FA.
+  This entry is accompanied by an entry for *Stranglehold*. Justin Jaeger's
+  entry was made 30 May 2004 in an unknown sector of the Black Hills with the
+  description "burly crimp sds." He gate it 1/5 stars. It is accompanied by
+  mulitple entries in *Irie Heights* such as *The Healing*, *The Offering*, and
+  *Tastes Like Burning* as well as a *Sport Action Arete* eliminate. This all
+  leads me to believe that *Give It the Finger* is a below average quality
+  problem. It is most likely located somewhere in *Irie Heights*, but has the
+  potential to be anywhere at Baldy, including along *Camp Judson Road*. The
+  name and descriptions imply that it is a crimpy sit start, likely with a stab
+  at some hold somehwere in the problem.
 
   [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BGive%20It%20the%20Finger%5D)
 
-- *Stroller*, V8-11
+- Several Ken Gibson problems near *Apparition*
 
-  From Dan Dewells and Michael Madsen's 8a scorecards. Dan Dewell's entry was made 6 June 2005 in an unknown sector of Old Baldy with a description "with the sickness." He gave it 3/5 stars, a rating of V8, and marked it as an FA. Michael Madsen's entry was made 16 February 2014 in *Cell One Valley*. He gave it 5/5 stars and a rating of V10. I have received some information, including a photo and an upgrade to V11, of this supposed problem but I remain skeptical. The photo is located at the "top" of *Cell One Valley* but looks *extremely improbable*, even for V11. If this was *Stroller*, I doubt Dan Dewell would've graded it V8 considering 1. he supposedly climbed it in June, 2. he repeated The Prow in December of the same year and gave it V10.
+  Supposedly these are problems in the range of V0-4 that run in a corridor
+  near or downhill from *Apparition*.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BKen%20Gibson%20Corridor%5D)
+
+- *Stroller*, V8-11, Dan Dewell
+
+  From Dan Dewells and Michael Madsen's 8a scorecards. Dan Dewell's entry was
+  made 6 June 2005 in an unknown sector of Old Baldy with a description "with
+  the sickness." He gave it 3/5 stars, a rating of V8, and marked it as an FA.
+  Michael Madsen's entry was made 16 February 2014 in *Cell One Valley*. He
+  gave it 5/5 stars and a rating of V10. I have received some information,
+  including a photo and an upgrade to V11, of this supposed problem but I
+  remain skeptical. The photo is located at the "top" of *Cell One Valley* but
+  looks *extremely improbable*, even for V11. If this was *Stroller*, I doubt
+  Dan Dewell would've graded it V8 considering 1. he supposedly climbed it in
+  June, 2. he repeated The Prow in December of the same year and gave it V10.
 
   [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BStroller%5D)
+
+
+- *Fit in the Sloper*, V4/5
+
+  From Dan Dewell's 8a scorecard. Entry was added 6 July 2005 in an uknown
+  sector at Baldy with the description "technically nota flash, but...". It was
+  also accompanied by entries on the same day of *Banshee* and *Ghost Town
+  Litigant*.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BFit%20in%20the%20Sloper%5D)
+
+  Dan's scorecard contained another kind of "unnamed" entry on the same day,
+  *Blake's Problem--left of 'Fit in the Sloper'*, V5/6. It had a description
+  "Blake should send LayDS next." It think this is a sarcastic remark that this
+  problem started abnormally low for the time.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BLeft%20of%20Fit%20in%20the%20Sloper%5D)
+
+- *Kung Fu Spotting*, V4/5
+
+  From Chipper Phillips' 8a scorecard. Entry was added 11 September 2005 in an
+  uknown sector of Baldy with the description "stressfulfalls-nicespotJJ." It
+  was accompanied by entries for *Jug City* and *Hueco Problem.* If I am to
+  believe Justin Jaeger was along for the ride on this one, then looking at
+  Justin's 8a scorecard, it is also accompanied by entries for *Banshee*,
+  *Ghost Town Litigant*, *The Rambunction*, *Award Tour*, *Jug City*,
+  *Skypager*, and *Organ Donor*. All this is to say, maybe it's in *Cell One
+  Valley* - or maybe it's just somewhere random at Baldy.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BKung%20Foo%20Spotting%5D)
+
+- *Stand and Deliver*, V8
+
+  From Dan Dewell's 8a scorecard. Entry was added 14 January 2006 in and
+  unknown sector of Mount Baldy with the description "big, tension-rich
+  movement." This entry was accompanied by an entry for *Sit Down and Be
+  Counted* and *Puff Daddy* on the same day. Therefore, I think it is likely
+  this problem is located in *Old Baldy's Melon Patch*. I think it's even more
+  likely the problem is located nearest *Sit Down and Be Counted* given how
+  similarly phrased its name is. It may even be a variation on the
+  aforementioned problem.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BStand%20and%20Deliver%5D)
+
+- *Deceptively Easy*, V3
+
+  From Kai Segrud's 8a scorecard. Entry was added 17 June 2006 at Old Baldy
+  with the description "Neat". It is accompanied by an entry on the same day
+  for *Wrestling With a Gerbil*.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BDeceptively%20Easy%5D)
+
+- *Bald Ass Bob*, V3, Lee Terveen
+
+  A short problem described to be me by Lee Terveen. It is located near the
+  west entrance to the *Sanitarium*, much further west, downhill, than the
+  *Superfly Boulder*. It is supposedly a sit start on the far left side of a
+  boulder's face and trends right on slopers. It was also mentioned there was a
+  boulder problem "behind it" which Lee considered more featured.
+
+  [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BBald%20Ass%20Bob%5D)
 
 ## Sylvan Lake
 
 - *Seared and Seething*, V4-7
 
-  From Justin Jaeger's 8a scorecard. Entry was added 31 May 2004 in an unknown sector of the Black Hills with the description "FA 2move roof V4-7?." He gave it 1/5 stars and marked it as an FA. Other entries from that same day include *Temper Tantrum*, *Hatori Hanso*, *Samurai*, and *Five Point Palm Exploding Heart Technique*. I have also receive information from a third party saying this problem resides at Sylvan Lake. I am unsure if it may belong to *The Outlets* - like at the *Don Juan Boulder* -, at the *Honeymoon Boulders*, or elsewhere.
+  From Justin Jaeger's 8a scorecard. Entry was added 31 May 2004 in an unknown
+  sector of the Black Hills with the description "FA 2move roof V4-7?." He gave
+  it 1/5 stars and marked it as an FA. Other entries from that same day include
+  *Temper Tantrum*, *Hatori Hanso*, *Samurai*, and *Five Point Palm Exploding
+  Heart Technique*. I have also receive information from a third party saying
+  this problem resides at Sylvan Lake. I am unsure if it may belong to *The
+  Outlets* - like at the *Don Juan Boulder* -, at the *Honeymoon Boulders*, or
+  elsewhere.
 
   [Email me with more information.](mailto:logan.grosz@gmail.com?subject=%5BInfo%20Request%5D%5BSeared%20and%20Seething%5D)
-
-
-
-


### PR DESCRIPTION
These are all my logged public info requests within the guidebook database as of 1 September 2023.

This patch also reformats all lines (except hyperlinks) to `textwidth=80`.