### PR TITLE
Adds table of contents to html generation

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -9,6 +9,7 @@ jobs:
         with:
           args: >-
             --standalone
+            --toc
             --metadata title="Public Information Requests"
             --output=info-requests.html
             info-requests.md


### PR DESCRIPTION
Uses `pandoc`s `--toc` option to create a table of contents on the generated html page.

Fixes #4