### PR TITLE
Moves info-requests to new service

### DIFF
--- a/.github/workflows/deploy-info-requests.yml
+++ b/.github/workflows/deploy-info-requests.yml
@@ -24,7 +24,7 @@ jobs:
             --standalone
             --toc
             --metadata title="Public Information Requests"
-            --output=www/info-requests.html
+            --output=www/index.html
             info-requests.md
       - uses: google-github-actions/auth@v1
         with:

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,4 @@
+service: info-requests
 runtime: python27
 api_version: 1
 threadsafe: true


### PR DESCRIPTION
This patch intends the info-requests static site to be accessible simply by following the web address https://info-requests.bhbouldering.com